### PR TITLE
Add Windows support via fixing path handling.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,6 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.hotovo.plugins"
-version = "0.1.0"
+version = "0.1.1"
 
 repositories {
     mavenCentral()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,6 +26,13 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <p>0.1.1</p>
+    <ul>
+      <li>Add Windows support via fixing path handling.</li>
+    </ul>
+  ]]></change-notes>
+
+    <change-notes><![CDATA[
     <p>0.1.0</p>
     <ul>
       <li>Initial release.</li>


### PR DESCRIPTION
The IntelliJ plugin was not working on Windows, while the VSCode extension functioned correctly. After comparing the logs of aider-desk for both the VSCode extension and the IntelliJ plugin, I discovered that the IntelliJ plugin was sending paths with / instead of \\, whereas the VSCode extension correctly used \\ on Windows.

This fix ensures that the IntelliJ plugin follows the correct path formatting based on the operating system, making it work properly on Windows and Linux too.